### PR TITLE
Add visualization docs and tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This directory contains comprehensive documentation for the FabricFriend project
 5. [Templates](templates.md) - Code templates for new modules
 6. [Utilities](utilities.md) - Common functionality and helper classes
 7. [Authentication](authentication.md) - Azure authentication and credential management
+8. [Visualization Utilities](visualiser.md) - Generating Azure topology diagrams
 
 ## Quick Start for Module Development
 

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -131,6 +131,25 @@ write_csv("output.csv", data_list)
 - **Modularity**: No circular dependencies - modules pass their schema to the utility
 - **Flexibility**: Accommodates additional columns in data that aren't in the base schema
 
+## Visualization Utilities (`visualisations.py`)
+
+These helpers use `networkx` and `matplotlib` to draw Azure topology diagrams.
+
+### `create_azure_topology_visualizations(output_dir, csv_schemas=None)`
+Reads CSV exports from `output_dir` and generates a set of hierarchy images.
+
+### `create_mgmt_group_subscription_viz(mgmt_groups_df, subscriptions_df, output_dir)`
+Shows management groups linked to their subscriptions.
+
+### `create_subscription_resource_group_viz(subscriptions_df, resource_groups_df, output_dir)`
+Plots subscriptions and their resource groups.
+
+### `create_resource_group_resources_viz(resource_groups_df, resources_df, output_dir)`
+Aggregates resources by type and creates a diagram for each resource group.
+
+### `create_complete_hierarchy_viz(mgmt_groups_df, subscriptions_df, resource_groups_df, resources_df, output_dir)`
+Builds a comprehensive hierarchy diagram combining all data.
+
 ## Usage in Main Program
 
 The utilities are used throughout the main program to:

--- a/docs/visualiser.md
+++ b/docs/visualiser.md
@@ -1,0 +1,20 @@
+# Visualization Utilities
+
+This document describes the helper functions found in `utils/visualisations.py`. These helpers use `networkx` and `matplotlib` to create diagrams that illustrate Azure management groups, subscriptions and resources.
+
+## Available Functions
+
+### `create_azure_topology_visualizations(output_dir, csv_schemas=None)`
+Reads topology CSV files from `output_dir` and generates a series of PNG images showing the hierarchy. Returns `True` when the visualizations are created successfully.
+
+### `create_mgmt_group_subscription_viz(mgmt_groups_df, subscriptions_df, output_dir)`
+Creates a graph linking management groups to their subscriptions.
+
+### `create_subscription_resource_group_viz(subscriptions_df, resource_groups_df, output_dir)`
+Visualizes the relationship between subscriptions and resource groups.
+
+### `create_resource_group_resources_viz(resource_groups_df, resources_df, output_dir)`
+Aggregates resources by type inside each resource group and produces a diagram.
+
+### `create_complete_hierarchy_viz(mgmt_groups_df, subscriptions_df, resource_groups_df, resources_df, output_dir)`
+Combines all levels of topology into a single comprehensive hierarchy visualization.

--- a/tests/test_visualisations.py
+++ b/tests/test_visualisations.py
@@ -1,0 +1,127 @@
+"""Tests for the visualization utilities"""
+
+import os
+import sys
+import tempfile
+
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+
+# Add repo root to path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.visualisations import (
+    create_mgmt_group_subscription_viz,
+    create_subscription_resource_group_viz,
+    create_resource_group_resources_viz,
+    create_complete_hierarchy_viz,
+    create_azure_topology_visualizations,
+)
+
+from unittest.mock import patch
+
+
+class TestVisualizationUtilities:
+    """Test suite for utils.visualisations"""
+
+    def test_create_mgmt_group_subscription_viz(self):
+        mgmt_df = pd.DataFrame([
+            {"id": "mg1", "name": "mg1", "display_name": "MG", "tenant_id": "t", "type": "mg"}
+        ])
+        subs_df = pd.DataFrame([
+            {"subscription_id": "sub1", "display_name": "Sub"}
+        ])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("utils.visualisations.plt.savefig") as mock_save:
+                with patch("utils.console.print"):
+                    create_mgmt_group_subscription_viz(mgmt_df, subs_df, temp_dir)
+                file_path = os.path.join(temp_dir, "mgmt_groups_subscriptions.png")
+                mock_save.assert_called_once()
+                assert mock_save.call_args[0][0] == file_path
+
+    def test_create_subscription_resource_group_viz(self):
+        subs_df = pd.DataFrame([
+            {"subscription_id": "sub1", "display_name": "Sub"}
+        ])
+        rgs_df = pd.DataFrame([
+            {"id": "rg1", "name": "RG", "subscription_id": "sub1"}
+        ])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("utils.visualisations.plt.savefig") as mock_save:
+                with patch("utils.console.print"):
+                    create_subscription_resource_group_viz(subs_df, rgs_df, temp_dir)
+                file_path = os.path.join(temp_dir, "subscriptions_resource_groups.png")
+                mock_save.assert_called_once()
+                assert mock_save.call_args[0][0] == file_path
+
+    def test_create_resource_group_resources_viz(self):
+        rgs_df = pd.DataFrame([
+            {"id": "rg1", "name": "RG"}
+        ])
+        resources_df = pd.DataFrame([
+            {"resource_group": "RG", "type": "vm"},
+            {"resource_group": "RG", "type": "vm"},
+        ])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("utils.visualisations.plt.savefig") as mock_save:
+                with patch("utils.console.print"):
+                    create_resource_group_resources_viz(rgs_df, resources_df, temp_dir)
+                file_path = os.path.join(temp_dir, "resource_groups_resources.png")
+                mock_save.assert_called_once()
+                assert mock_save.call_args[0][0] == file_path
+
+    def test_create_complete_hierarchy_viz(self):
+        mgmt_df = pd.DataFrame([
+            {"id": "mg1", "name": "mg1", "display_name": "MG", "tenant_id": "t", "type": "mg"}
+        ])
+        subs_df = pd.DataFrame([
+            {"subscription_id": "sub1", "display_name": "Sub"}
+        ])
+        rgs_df = pd.DataFrame([
+            {"id": "rg1", "name": "RG", "subscription_id": "sub1"}
+        ])
+        resources_df = pd.DataFrame([
+            {"resource_group": "RG", "type": "vm"}
+        ])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("utils.visualisations.plt.savefig") as mock_save:
+                with patch("utils.console.print"):
+                    create_complete_hierarchy_viz(mgmt_df, subs_df, rgs_df, resources_df, temp_dir)
+                file_path = os.path.join(temp_dir, "complete_azure_hierarchy.png")
+                mock_save.assert_called_once()
+                assert mock_save.call_args[0][0] == file_path
+
+    def test_create_azure_topology_visualizations(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mgmt_df = pd.DataFrame([
+                {"id": "mg1", "name": "mg1", "display_name": "MG", "tenant_id": "t", "type": "mg"}
+            ])
+            subs_df = pd.DataFrame([
+                {"subscription_id": "sub1", "display_name": "Sub"}
+            ])
+            rgs_df = pd.DataFrame([
+                {"id": "rg1", "name": "RG", "subscription_id": "sub1"}
+            ])
+            resources_df = pd.DataFrame([
+                {"resource_group": "RG", "type": "vm"}
+            ])
+
+            mgmt_df.to_csv(os.path.join(temp_dir, "management_groups.csv"), index=False)
+            subs_df.to_csv(os.path.join(temp_dir, "subscriptions.csv"), index=False)
+            rgs_df.to_csv(os.path.join(temp_dir, "resource_groups.csv"), index=False)
+            resources_df.to_csv(os.path.join(temp_dir, "resources.csv"), index=False)
+
+            with (
+                patch("utils.visualisations.create_mgmt_group_subscription_viz") as m1,
+                patch("utils.visualisations.create_subscription_resource_group_viz") as m2,
+                patch("utils.visualisations.create_resource_group_resources_viz") as m3,
+                patch("utils.visualisations.create_complete_hierarchy_viz") as m4,
+                patch("utils.console.print")
+            ):
+                result = create_azure_topology_visualizations(temp_dir)
+                assert result is True
+                m1.assert_called_once()
+                m2.assert_called_once()
+                m3.assert_called_once()
+                m4.assert_called_once()


### PR DESCRIPTION
## Summary
- document visualization utility usage and add to docs table of contents
- describe visualization utilities in the utilities overview
- add dedicated documentation page for visualisation helpers
- implement tests covering `utils.visualisations`
- fix patch paths in tests for console

## Testing
- `pytest -q`